### PR TITLE
skip password change for first login in Zitadel

### DIFF
--- a/zitadel/zitadel.go
+++ b/zitadel/zitadel.go
@@ -99,6 +99,7 @@ func WithAdminUser(username, password string) testcontainers.CustomizeRequestOpt
 	return func(req *testcontainers.GenericContainerRequest) error {
 		req.Env["ZITADEL_FIRSTINSTANCE_ORG_HUMAN_USERNAME"] = username
 		req.Env["ZITADEL_FIRSTINSTANCE_ORG_HUMAN_PASSWORD"] = password
+		req.Env["ZITADEL_FIRSTINSTANCE_ORG_HUMAN_PASSWORDCHANGEREQUIRED"] = "false"
 		return nil
 	}
 }


### PR DESCRIPTION
This PR modifies Zitadel module to skip password change for first login. Considering this module is for a mock environment:

- There is no security concerns for not changing password
- The user can still change his/her password through settings page

This change can simplify E2E tests using this module, as we can skip first login check and password modification.