### PR TITLE
fix(nats): use listening port as wait strategy

### DIFF
--- a/nats/nats.go
+++ b/nats/nats.go
@@ -43,7 +43,7 @@ func New(p RequestParams) (*testcontainers.GenericContainerRequest, error) {
 			ExposedPorts: []string{Port, HttpPort, RoutePort},
 			Env:          map[string]string{},
 			Cmd:          []string{"-DV", "-js"},
-			WaitingFor:   wait.ForLog("Listening for client connections on 0.0.0.0:4222"),
+			WaitingFor:   wait.ForListeningPort(Port),
 		},
 		Started: true,
 	}


### PR DESCRIPTION
This changes the wait strategy of nats module to listening to main nats port. It solves the issue that the container is not ready when the log message is printed, causing random test failures.