### PR TITLE
added with authz model decorator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/minio/minio-go/v7 v7.0.95
 	github.com/nats-io/nats.go v1.33.1
 	github.com/openfga/go-sdk v0.7.1
+	github.com/openfga/language/pkg/go v0.2.0-beta.2
 	github.com/ory/hydra-client-go v1.11.8
 	github.com/testcontainers/testcontainers-go v0.37.0
 	github.com/testcontainers/testcontainers-go/modules/nats v0.37.0
@@ -25,12 +26,14 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.13.0
 	go.temporal.io/sdk v1.35.0
 	go.uber.org/fx v1.24.0
+	google.golang.org/protobuf v1.36.6
 )
 
 require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
@@ -58,6 +61,8 @@ require (
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
@@ -82,6 +87,7 @@ require (
 	github.com/oapi-codegen/runtime v1.1.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/openfga/api/proto v0.0.0-20240905181937-3583905f61a6 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -124,7 +130,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250603155806-513f23925822 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250603155806-513f23925822 // indirect
 	google.golang.org/grpc v1.73.0 // indirect
-	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/go-jose/go-jose.v2 v2.6.3 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
+github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
+github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -179,6 +181,11 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDa
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 h1:X5VWvz21y3gzm9Nw/kaUeku/1+uBhcekkmy4IkffJww=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1/go.mod h1:Zanoh4+gvIgluNqcfMVTJueD4wSS5hT7zTt4Mrutd90=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
+github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -266,8 +273,12 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
+github.com/openfga/api/proto v0.0.0-20240905181937-3583905f61a6 h1:U2uLZPYSAZDk5fnQdsNc0+Iu6GNdbVyk7omtnhl6C8g=
+github.com/openfga/api/proto v0.0.0-20240905181937-3583905f61a6/go.mod h1:gil5LBD8tSdFQbUkCQdnXsoeU9kDJdJgbGdHkgJfcd0=
 github.com/openfga/go-sdk v0.7.1 h1:ZFFDRoSWAHcbOzPFUWPLUpoIOJZRoQ6KgJp2vyfB82g=
 github.com/openfga/go-sdk v0.7.1/go.mod h1:Fu00XYLWkfgmo3PV45EwSOhpaBNcuVMBOdklpKoaazw=
+github.com/openfga/language/pkg/go v0.2.0-beta.2 h1:PH4AOYSREgkMZSHO+RLOwkCLcg/i1cTxrVJraM6/YT4=
+github.com/openfga/language/pkg/go v0.2.0-beta.2/go.mod h1:ll/hN6kS4EE6B/7J/PbZqac9Nuv7ZHpI+Jfh36JLrbs=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/ory/hydra-client-go v1.11.8 h1:GwJjvH/DBcfYzoST4vUpi4pIRzDGH5oODKpIVuhwVyc=
 github.com/ory/hydra-client-go v1.11.8/go.mod h1:4YuBuwUEC4yiyDrnKjGYc1tB3gUXan4ZiUYMjXJbfxA=

--- a/openfga/openfga_test.go
+++ b/openfga/openfga_test.go
@@ -13,6 +13,22 @@ import (
 	"go.uber.org/fx/fxtest"
 )
 
+const fixture = `
+model
+  schema 1.1
+
+type employee
+  relations
+    define can_manage: manager or can_manage from manager
+    define manager: [employee]
+
+type report
+  relations
+    define approver: can_manage from submitter
+    define submitter: [employee]
+
+`
+
 func TestOpenFGAModule_SmokeTest(t *testing.T) {
 	app := fxtest.New(
 		t,
@@ -97,6 +113,66 @@ func TestOpenFGAModule_WithPresharedKey(t *testing.T) {
 			_, err = fgaClient.ListStores(t.Context()).Options(ClientListStoresOptions{}).Execute()
 			if err != nil {
 				t.Fatalf("Failed to list OpenFGA stores: %v", err)
+			}
+		}),
+	)
+	app.RequireStart()
+	t.Cleanup(func() {
+		app.RequireStop()
+	})
+}
+
+func TestOpenFGAModule_WithAuthorizationModel(t *testing.T) {
+	token := "random-test-token"
+	app := fxtest.New(
+		t,
+		fx.NopLogger,
+		fx.Supply(
+			fx.Annotate(
+				"latest",
+				fx.ResultTags(`name:"openfga_version"`),
+			),
+			fx.Annotate(
+				fmt.Sprintf("openfga-test-%x", time.Now().Unix()),
+				fx.ResultTags(`name:"prefix"`),
+			),
+		),
+		container.Module(
+			container.WithPresharedKey(token),
+			container.WithAuthorizationModel(fixture, func(storeID, authModelID string) error {
+				if storeID == "" || authModelID == "" {
+					return fmt.Errorf("store ID or authorization model ID is empty")
+				}
+				// Here you can add additional checks or operations with the store and auth model IDs
+				return nil
+			}),
+		),
+		fx.Invoke(func(params struct {
+			fx.In
+			Container testcontainers.Container `name:"openfga"`
+		}) {
+			endpoint, err := params.Container.PortEndpoint(t.Context(), container.HttpPort, "")
+			if err != nil {
+				t.Fatalf("Failed to get OpenFGA container endpoint: %v", err)
+			}
+			fgaClient, err := NewSdkClient(&ClientConfiguration{
+				ApiUrl: fmt.Sprintf("http://%s", endpoint),
+				Credentials: &credentials.Credentials{
+					Method: credentials.CredentialsMethodApiToken,
+					Config: &credentials.Config{
+						ApiToken: token,
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("Failed to create OpenFGA client: %v", err)
+			}
+			stores, err := fgaClient.ListStores(t.Context()).Options(ClientListStoresOptions{}).Execute()
+			if err != nil {
+				t.Fatalf("Failed to list OpenFGA stores: %v", err)
+			}
+			if len(stores.Stores) == 0 {
+				t.Fatalf("No stores found in OpenFGA")
 			}
 		}),
 	)


### PR DESCRIPTION
This PR introduces support for injecting openfga DSL format authorization model into the container directly as a postreadyhook for testcontainers