### PR TITLE
Use result object type for return type of module constructor

### DIFF
--- a/lgtm/lgtm.go
+++ b/lgtm/lgtm.go
@@ -65,10 +65,16 @@ type ContainerParams struct {
 	Request   *testcontainers.GenericContainerRequest `name:"lgtm"`
 }
 
-func Actualize(p ContainerParams) (testcontainers.Container, error) {
+type Result struct {
+	fx.Out
+	Container      testcontainers.Container `name:"lgtm"`
+	ContainerGroup testcontainers.Container `group:"containers"`
+}
+
+func Actualize(p ContainerParams) (Result, error) {
 	c, err := testcontainers.GenericContainer(context.Background(), *p.Request)
 	if err != nil {
-		return nil, err
+		return Result{}, err
 	}
 
 	p.Lifecycle.Append(fx.Hook{
@@ -104,7 +110,10 @@ func Actualize(p ContainerParams) (testcontainers.Container, error) {
 			return err
 		},
 	})
-	return c, nil
+	return Result{
+		Container:      c,
+		ContainerGroup: c,
+	}, nil
 }
 
 var Module = mockestra.BuildContainerModule(
@@ -114,9 +123,6 @@ var Module = mockestra.BuildContainerModule(
 			New,
 			fx.ResultTags(`name:"lgtm"`),
 		),
-		fx.Annotate(
-			Actualize,
-			fx.ResultTags(`name:"lgtm"`),
-		),
+		Actualize,
 	),
 )

--- a/lgtm/lgtm_test.go
+++ b/lgtm/lgtm_test.go
@@ -65,7 +65,5 @@ func TestLGTMModule(t *testing.T) {
 		}),
 	)
 	app.RequireStart()
-	t.Cleanup(func() {
-		app.RequireStop()
-	})
+	t.Cleanup(app.RequireStop)
 }

--- a/mailslurper/mailslurper_test.go
+++ b/mailslurper/mailslurper_test.go
@@ -50,7 +50,5 @@ func TestMailslurperModule(t *testing.T) {
 	)
 
 	app.RequireStart()
-	t.Cleanup(func() {
-		app.RequireStop()
-	})
+	t.Cleanup(app.RequireStop)
 }

--- a/minio/minio_test.go
+++ b/minio/minio_test.go
@@ -109,7 +109,5 @@ func TestMinioModule_WithBucket(t *testing.T) {
 	)
 
 	app.RequireStart()
-	t.Cleanup(func() {
-		app.RequireStop()
-	})
+	t.Cleanup(app.RequireStop)
 }

--- a/nats/nats_test.go
+++ b/nats/nats_test.go
@@ -48,7 +48,5 @@ func TestNATSModule(t *testing.T) {
 	)
 
 	app.RequireStart()
-	t.Cleanup(func() {
-		app.RequireStop()
-	})
+	t.Cleanup(app.RequireStop)
 }

--- a/openfga/openfga.go
+++ b/openfga/openfga.go
@@ -149,13 +149,19 @@ type ContainerParams struct {
 	Request   *testcontainers.GenericContainerRequest `name:"openfga"`
 }
 
-func Actualize(p ContainerParams) (testcontainers.Container, error) {
+type Result struct {
+	fx.Out
+	Container      testcontainers.Container `name:"openfga"`
+	ContainerGroup testcontainers.Container `group:"containers"`
+}
+
+func Actualize(p ContainerParams) (Result, error) {
 	c, err := testcontainers.GenericContainer(
 		context.Background(),
 		*p.Request,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create OpenFGA container: %w", err)
+		return Result{}, fmt.Errorf("failed to create OpenFGA container: %w", err)
 	}
 	p.Lifecycle.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
@@ -186,7 +192,10 @@ func Actualize(p ContainerParams) (testcontainers.Container, error) {
 			return err
 		},
 	})
-	return c, nil
+	return Result{
+		Container:      c,
+		ContainerGroup: c,
+	}, nil
 }
 
 var WithPostReadyHook = mockestra.WithPostReadyHook
@@ -198,9 +207,6 @@ var Module = mockestra.BuildContainerModule(
 			New,
 			fx.ResultTags(`name:"openfga"`),
 		),
-		fx.Annotate(
-			Actualize,
-			fx.ResultTags(`name:"openfga"`),
-		),
+		Actualize,
 	),
 )

--- a/openfga/openfga_test.go
+++ b/openfga/openfga_test.go
@@ -67,9 +67,7 @@ func TestOpenFGAModule_SmokeTest(t *testing.T) {
 
 	app.RequireStart()
 
-	t.Cleanup(func() {
-		app.RequireStop()
-	})
+	t.Cleanup(app.RequireStop)
 }
 
 func TestOpenFGAModule_WithPresharedKey(t *testing.T) {
@@ -117,9 +115,7 @@ func TestOpenFGAModule_WithPresharedKey(t *testing.T) {
 		}),
 	)
 	app.RequireStart()
-	t.Cleanup(func() {
-		app.RequireStop()
-	})
+	t.Cleanup(app.RequireStop)
 }
 
 func TestOpenFGAModule_WithAuthorizationModel(t *testing.T) {
@@ -177,7 +173,5 @@ func TestOpenFGAModule_WithAuthorizationModel(t *testing.T) {
 		}),
 	)
 	app.RequireStart()
-	t.Cleanup(func() {
-		app.RequireStop()
-	})
+	t.Cleanup(app.RequireStop)
 }

--- a/postgres/postgres_test.go
+++ b/postgres/postgres_test.go
@@ -160,7 +160,5 @@ func TestPostgresModule(t *testing.T) {
 	)
 
 	app.RequireStart()
-	t.Cleanup(func() {
-		app.RequireStop()
-	})
+	t.Cleanup(app.RequireStop)
 }

--- a/temporal/temporal.go
+++ b/temporal/temporal.go
@@ -59,10 +59,16 @@ type ContainerParams struct {
 	Request   *testcontainers.GenericContainerRequest `name:"temporal"`
 }
 
-func Actualize(p ContainerParams) (testcontainers.Container, error) {
+type Result struct {
+	fx.Out
+	Container      testcontainers.Container `name:"temporal"`
+	ContainerGroup testcontainers.Container `group:"containers"`
+}
+
+func Actualize(p ContainerParams) (Result, error) {
 	c, err := testcontainers.GenericContainer(context.Background(), *p.Request)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create %s container: %w", ContainerPrettyName, err)
+		return Result{}, fmt.Errorf("failed to create %s container: %w", ContainerPrettyName, err)
 	}
 	p.Lifecycle.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
@@ -93,7 +99,10 @@ func Actualize(p ContainerParams) (testcontainers.Container, error) {
 			return err
 		},
 	})
-	return c, nil
+	return Result{
+		Container:      c,
+		ContainerGroup: c,
+	}, nil
 }
 
 var WithPostReadyHook = mockestra.WithPostReadyHook
@@ -105,9 +114,6 @@ var Module = mockestra.BuildContainerModule(
 			New,
 			fx.ResultTags(`name:"temporal"`),
 		),
-		fx.Annotate(
-			Actualize,
-			fx.ResultTags(`name:"temporal"`),
-		),
+		Actualize,
 	),
 )

--- a/temporal/temporal_test.go
+++ b/temporal/temporal_test.go
@@ -46,7 +46,5 @@ func TestTemporalModule(t *testing.T) {
 	)
 
 	app.RequireStart()
-	t.Cleanup(func() {
-		app.RequireStop()
-	})
+	t.Cleanup(app.RequireStop)
 }

--- a/timescaledb/timescaledb.go
+++ b/timescaledb/timescaledb.go
@@ -89,14 +89,20 @@ type ContainerParams struct {
 	Request   *testcontainers.GenericContainerRequest `name:"timescaledb"`
 }
 
+type Result struct {
+	fx.Out
+	Container      testcontainers.Container `name:"timescaledb"`
+	ContainerGroup testcontainers.Container `group:"containers"`
+}
+
 // Actualize is a constructor that returns a testcontainers.Container
 // it consumes previously instantiated testcontainers.GenericContainerRequest
 // as part of its inputs, alongside with other tag specified testcontainers.GenericContainerRequest
 // in order to reconcile its lifecycle dependencies before creating a testcontainers.Container.
-func Actualize(p ContainerParams) (testcontainers.Container, error) {
+func Actualize(p ContainerParams) (Result, error) {
 	c, err := testcontainers.GenericContainer(context.Background(), *p.Request)
 	if err != nil {
-		return nil, fmt.Errorf("an error occurred while instantiating %s container: %w", ContainerPrettyName, err)
+		return Result{}, fmt.Errorf("an error occurred while instantiating %s container: %w", ContainerPrettyName, err)
 	}
 	p.Lifecycle.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
@@ -117,7 +123,10 @@ func Actualize(p ContainerParams) (testcontainers.Container, error) {
 			return err
 		},
 	})
-	return c, nil
+	return Result{
+		Container:      c,
+		ContainerGroup: c,
+	}, nil
 }
 
 var WithPostReadyHook = mockestra.WithPostReadyHook
@@ -129,9 +138,6 @@ var Module = mockestra.BuildContainerModule(
 			New,
 			fx.ResultTags(`name:"timescaledb"`),
 		),
-		fx.Annotate(
-			Actualize,
-			fx.ResultTags(`name:"timescaledb"`),
-		),
+		Actualize,
 	),
 )

--- a/timescaledb/timescaledb_test.go
+++ b/timescaledb/timescaledb_test.go
@@ -131,7 +131,5 @@ func TestTimescaleDBModule(t *testing.T) {
 	)
 
 	app.RequireStart()
-	t.Cleanup(func() {
-		app.RequireStop()
-	})
+	t.Cleanup(app.RequireStop)
 }

--- a/typesense/typesense.go
+++ b/typesense/typesense.go
@@ -68,10 +68,16 @@ type ContainerParams struct {
 	Request   *testcontainers.GenericContainerRequest `name:"typesense"`
 }
 
-func Actualize(p ContainerParams) (testcontainers.Container, error) {
+type Result struct {
+	fx.Out
+	Container      testcontainers.Container `name:"typesense"`
+	ContainerGroup testcontainers.Container `group:"containers"`
+}
+
+func Actualize(p ContainerParams) (Result, error) {
 	c, err := testcontainers.GenericContainer(context.Background(), *p.Request)
 	if err != nil {
-		return nil, fmt.Errorf("an error occurred while instantiating typesense container: %w", err)
+		return Result{}, fmt.Errorf("an error occurred while instantiating typesense container: %w", err)
 	}
 	p.Lifecycle.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
@@ -92,7 +98,10 @@ func Actualize(p ContainerParams) (testcontainers.Container, error) {
 			return err
 		},
 	})
-	return c, nil
+	return Result{
+		Container:      c,
+		ContainerGroup: c,
+	}, nil
 }
 
 var WithPostReadyHook = mockestra.WithPostReadyHook
@@ -104,9 +113,6 @@ var Module = mockestra.BuildContainerModule(
 			New,
 			fx.ResultTags(`name:"typesense"`),
 		),
-		fx.Annotate(
-			Actualize,
-			fx.ResultTags(`name:"typesense"`),
-		),
+		Actualize,
 	),
 )

--- a/typesense/typesense_test.go
+++ b/typesense/typesense_test.go
@@ -51,7 +51,5 @@ func TestTypesenseModule(t *testing.T) {
 	)
 
 	app.RequireStart()
-	t.Cleanup(func() {
-		app.RequireStop()
-	})
+	t.Cleanup(app.RequireStop)
 }

--- a/valkey/valkey.go
+++ b/valkey/valkey.go
@@ -53,10 +53,16 @@ type ContainerParams struct {
 	Request   *testcontainers.GenericContainerRequest `name:"valkey"`
 }
 
-func Actualize(p ContainerParams) (testcontainers.Container, error) {
+type Result struct {
+	fx.Out
+	Container      testcontainers.Container `name:"valkey"`
+	ContainerGroup testcontainers.Container `group:"containers"`
+}
+
+func Actualize(p ContainerParams) (Result, error) {
 	c, err := testcontainers.GenericContainer(context.Background(), *p.Request)
 	if err != nil {
-		return nil, fmt.Errorf("an error occurred while instantiating %s container: %w", ContainerPrettyName, err)
+		return Result{}, fmt.Errorf("an error occurred while instantiating %s container: %w", ContainerPrettyName, err)
 	}
 
 	p.Lifecycle.Append(fx.Hook{
@@ -78,7 +84,10 @@ func Actualize(p ContainerParams) (testcontainers.Container, error) {
 			return err
 		},
 	})
-	return c, nil
+	return Result{
+		Container:      c,
+		ContainerGroup: c,
+	}, nil
 }
 
 var WithPostReadyHook = mockestra.WithPostReadyHook
@@ -90,9 +99,6 @@ var Module = mockestra.BuildContainerModule(
 			New,
 			fx.ResultTags(`name:"valkey"`),
 		),
-		fx.Annotate(
-			Actualize,
-			fx.ResultTags(`name:"valkey"`),
-		),
+		Actualize,
 	),
 )

--- a/valkey/valkey_test.go
+++ b/valkey/valkey_test.go
@@ -44,7 +44,5 @@ func TestValKeyModule(t *testing.T) {
 	)
 
 	app.RequireStart()
-	t.Cleanup(func() {
-		app.RequireStop()
-	})
+	t.Cleanup(app.RequireStop)
 }


### PR DESCRIPTION
This PR introduces adjustment to the return type of the `Actualize` constructor in the modules. It enables usage for consuming value group as such
```golang
type Params struct {
  fx.In
  Containers testcontainers.Containers `"group:containers"`
}
```