### PR TITLE
Create access proxy for concourse module

### DIFF
--- a/concourse/concourse.go
+++ b/concourse/concourse.go
@@ -62,13 +62,14 @@ func WithSecret(secret string) testcontainers.CustomizeRequestOption {
 }
 
 func New(p RequestParams) (*testcontainers.GenericContainerRequest, error) {
+	_, portNumber := nat.SplitProtoPort(Port)
 	r := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
 			Image:        fmt.Sprintf("%s:%s", Image, p.Version),
 			Name:         fmt.Sprintf("mock-%s-%s", p.Prefix, Tag),
 			ExposedPorts: []string{Port},
 			Env: map[string]string{
-				"CONCOURSE_EXTERNAL_URL":                 "http://localhost:8080",
+				"CONCOURSE_EXTERNAL_URL":                 fmt.Sprintf("http://%s:%s", mockestra.LoopbackAddress, portNumber),
 				"CONCOURSE_WORKER_BAGGAGECLAIM_DRIVER":   "overlay",
 				"CONCOURSE_X_FRAME_OPTIONS":              "allow",
 				"CONCOURSE_CONTENT_SECURITY_POLICY":      "frame-ancestors *;",

--- a/concourse/concourse.go
+++ b/concourse/concourse.go
@@ -173,5 +173,9 @@ var Module = mockestra.BuildContainerModule(
 			fx.ResultTags(`name:"concourse"`),
 		),
 		Actualize,
+		fx.Annotate(
+			NewProxy("API", nat.Port(Port)),
+			fx.ResultTags(`name:"concourse"`),
+		),
 	),
 )

--- a/concourse/concourse_test.go
+++ b/concourse/concourse_test.go
@@ -279,9 +279,9 @@ func TestConcourseModule_Proxy(t *testing.T) {
 		),
 		fx.Invoke(func(params struct {
 			fx.In
-			Proxy *proxy.TCPProxy `name:"concourse"`
+			Request *testcontainers.GenericContainerRequest `name:"concourse"`
+			Proxy   *proxy.TCPProxy                         `name:"concourse"`
 		}) {
-
 			t.Run("proxy listen address", func(t *testing.T) {
 				expectedHostPort := net.JoinHostPort(mockestra.LoopbackAddress, nat.Port(container.Port).Port())
 				if params.Proxy.ListenAddress != expectedHostPort {
@@ -291,6 +291,12 @@ func TestConcourseModule_Proxy(t *testing.T) {
 
 			// this test is the same as TestConcourseModule, but uses the access proxy IP and port
 			endpoint := fmt.Sprintf("http://%s", params.Proxy.ListenAddress)
+
+			t.Run("container environment variable", func(t *testing.T) {
+				if params.Request.Env["CONCOURSE_EXTERNAL_URL"] != endpoint {
+					t.Fatalf("Expected container environment variable CONCOURSE_EXTERNAL_URL to be %s, got %s", endpoint, params.Request.Env["CONCOURSE_EXTERNAL_URL"])
+				}
+			})
 
 			// Oauth client configuration for local username password login in Fly CLI
 			oauth2Config := oauth2.Config{

--- a/concourse/proxy.go
+++ b/concourse/proxy.go
@@ -1,0 +1,49 @@
+package concourse
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+
+	"github.com/docker/go-connections/nat"
+	"github.com/narwhl/mockestra"
+	"github.com/narwhl/mockestra/proxy"
+	"github.com/testcontainers/testcontainers-go"
+	"go.uber.org/fx"
+)
+
+type ProxyParams struct {
+	fx.In
+	ConcourseContainer testcontainers.Container `name:"concourse"`
+	Lifecycle          fx.Lifecycle
+}
+
+func NewProxy(portName string, port nat.Port) func(p ProxyParams) (*proxy.TCPProxy, error) {
+	return func(p ProxyParams) (*proxy.TCPProxy, error) {
+		concourseEndpoint, err := p.ConcourseContainer.PortEndpoint(context.Background(), port, "")
+		if err != nil {
+			return nil, fmt.Errorf("failed to get concourse %s endpoint: %w", portName, err)
+		}
+		accessProxy := proxy.TCPProxy{
+			ListenAddress: net.JoinHostPort(mockestra.LoopbackAddress, port.Port()),
+			TargetAddress: concourseEndpoint,
+		}
+		if err := accessProxy.Start(context.Background()); err != nil {
+			return nil, fmt.Errorf("failed to start %s %s access proxy: %w", ContainerPrettyName, portName, err)
+		}
+		p.Lifecycle.Append(fx.Hook{
+			OnStart: func(ctx context.Context) error {
+				slog.Info(fmt.Sprintf("Forwarding %s %s traffic via proxy", ContainerPrettyName, portName), "from_addr", accessProxy.ListenAddress, "to_addr", accessProxy.TargetAddress)
+				return nil
+			},
+			OnStop: func(ctx context.Context) error {
+				if err := accessProxy.Close(ctx); err != nil {
+					return fmt.Errorf("failed to stop %s %s access proxy: %w", ContainerPrettyName, portName, err)
+				}
+				return nil
+			},
+		})
+		return &accessProxy, nil
+	}
+}


### PR DESCRIPTION
This PR creates access proxy for concourse module as the frontend requires a hardcoded `CONCOURSE_EXTERNAL_URL` for rendering URLs.