### PR TITLE
feat(kanidm): module implementation

### DIFF
--- a/kanidm/kanidm.go
+++ b/kanidm/kanidm.go
@@ -1,0 +1,101 @@
+package kanidm
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/docker/go-connections/nat"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"go.uber.org/fx"
+)
+
+const (
+	Tag                 = "kanidm"
+	Image               = "kanidm/server"
+	Port                = "8443/tcp"
+	LDAPPort            = "3636/tcp"
+	ContainerPrettyName = "kanidm"
+)
+
+type RequestParams struct {
+	fx.In
+	Prefix  string                               `name:"prefix"`
+	Version string                               `name:"kanidm_version"`
+	Opts    []testcontainers.ContainerCustomizer `group:"kanidm"`
+}
+
+func New(p RequestParams) (*testcontainers.GenericContainerRequest, error) {
+	r := testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Name:  fmt.Sprintf("mock-%s-%s", p.Prefix, Tag),
+			Image: fmt.Sprintf("%s:%s", Image, p.Version),
+			ExposedPorts: []string{
+				Port,
+			},
+			WaitingFor: wait.ForLog(".*[info]: ready to rock!.*\\s").AsRegexp().WithOccurrence(1),
+		},
+		Started: true,
+	}
+
+	for _, opt := range p.Opts {
+		if err := opt.Customize(&r); err != nil {
+			return nil, err
+		}
+	}
+
+	return &r, nil
+}
+
+type ContainerParams struct {
+	fx.In
+	Lifecycle fx.Lifecycle
+	Request   *testcontainers.GenericContainerRequest `name:"kanidm"`
+}
+
+type Result struct {
+	fx.Out
+	Container      testcontainers.Container `name:"kanidm"`
+	ContainerGroup testcontainers.Container `name:"containers"`
+}
+
+func Actualize(p ContainerParams) (Result, error) {
+	c, err := testcontainers.GenericContainer(context.Background(), *p.Request)
+	if err != nil {
+		return Result{}, err
+	}
+
+	p.Lifecycle.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			portLabels := map[string]string{
+				Port: "https",
+			}
+			var ports []any
+			for port, label := range portLabels {
+				p, err := c.MappedPort(ctx, nat.Port(port))
+				if err != nil {
+					return fmt.Errorf("failed to get mapped port for %s: %w", port, err)
+				}
+				ports = append(ports, label)
+				ports = append(ports, fmt.Sprintf("localhost:%s", p.Port()))
+			}
+			slog.Info(fmt.Sprintf("%s container is running", ContainerPrettyName), ports...)
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			err := c.Terminate(ctx)
+			if err != nil {
+				slog.Warn(fmt.Sprintf("an error occurred while terminating %s container", ContainerPrettyName), "error", err)
+			} else {
+				slog.Info(fmt.Sprintf("%s container is terminated", ContainerPrettyName))
+			}
+			return err
+		},
+	})
+
+	return Result{
+		Container:      c,
+		ContainerGroup: c,
+	}, nil
+}

--- a/kanidm/kanidm.go
+++ b/kanidm/kanidm.go
@@ -1,11 +1,21 @@
 package kanidm
 
 import (
+	"bytes"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
 	"log/slog"
+	"math/big"
+	"time"
 
 	"github.com/docker/go-connections/nat"
+	"github.com/narwhl/mockestra"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"go.uber.org/fx"
@@ -16,8 +26,141 @@ const (
 	Image               = "kanidm/server"
 	Port                = "8443/tcp"
 	LDAPPort            = "3636/tcp"
-	ContainerPrettyName = "kanidm"
+	ContainerPrettyName = "Kanidm"
+
+	DefaultDomain = "idm.example.com"
+	DefaultOrigin = "https://idm.example.com:8443"
 )
+
+// WithDomain sets the DNS domain name of the server.
+// This is used in security-critical contexts such as webauthn.
+func WithDomain(domain string) testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) error {
+		req.Env["KANIDM_DOMAIN"] = domain
+		return nil
+	}
+}
+
+// WithOrigin sets the origin URL for webauthn.
+// This must match or be a descendant of the domain name.
+func WithOrigin(origin string) testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) error {
+		req.Env["KANIDM_ORIGIN"] = origin
+		return nil
+	}
+}
+
+// WithBindAddress sets the webserver bind address.
+func WithBindAddress(addr string) testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) error {
+		req.Env["KANIDM_BINDADDRESS"] = addr
+		return nil
+	}
+}
+
+// WithLDAPBindAddress sets the LDAP server bind address.
+// If set, the LDAP port will be exposed.
+func WithLDAPBindAddress(addr string) testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) error {
+		req.Env["KANIDM_LDAPBINDADDRESS"] = addr
+		// Ensure LDAP port is exposed
+		hasLDAPPort := false
+		for _, port := range req.ExposedPorts {
+			if port == LDAPPort {
+				hasLDAPPort = true
+				break
+			}
+		}
+		if !hasLDAPPort {
+			req.ExposedPorts = append(req.ExposedPorts, LDAPPort)
+		}
+		return nil
+	}
+}
+
+// WithLogLevel sets the log level of the server.
+// Valid values are: info, debug, trace.
+func WithLogLevel(level string) testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) error {
+		req.Env["KANIDM_LOG_LEVEL"] = level
+		return nil
+	}
+}
+
+// WithDBPath sets the path to the kanidm database.
+func WithDBPath(path string) testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) error {
+		req.Env["KANIDM_DB_PATH"] = path
+		return nil
+	}
+}
+
+// WithDBFSType sets the filesystem type for database tuning.
+// Valid values are: zfs, other.
+func WithDBFSType(fsType string) testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) error {
+		req.Env["KANIDM_DB_FS_TYPE"] = fsType
+		return nil
+	}
+}
+
+// WithDBArcSize sets the number of entries to store in the in-memory cache.
+// Minimum value is 256.
+func WithDBArcSize(size int) testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) error {
+		req.Env["KANIDM_DB_ARC_SIZE"] = fmt.Sprintf("%d", size)
+		return nil
+	}
+}
+
+// generateSelfSignedCert generates a self-signed TLS certificate for testing.
+func generateSelfSignedCert(domain string) (certPEM, keyPEM []byte, err error) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate private key: %w", err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Mockestra Test"},
+			CommonName:   domain,
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{domain, "localhost"},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create certificate: %w", err)
+	}
+
+	certBuf := new(bytes.Buffer)
+	if err := pem.Encode(certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); err != nil {
+		return nil, nil, fmt.Errorf("failed to encode certificate: %w", err)
+	}
+
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal private key: %w", err)
+	}
+
+	keyBuf := new(bytes.Buffer)
+	if err := pem.Encode(keyBuf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}); err != nil {
+		return nil, nil, fmt.Errorf("failed to encode private key: %w", err)
+	}
+
+	return certBuf.Bytes(), keyBuf.Bytes(), nil
+}
 
 type RequestParams struct {
 	fx.In
@@ -27,6 +170,12 @@ type RequestParams struct {
 }
 
 func New(p RequestParams) (*testcontainers.GenericContainerRequest, error) {
+	// Generate self-signed TLS certificates for the container
+	certPEM, keyPEM, err := generateSelfSignedCert(DefaultDomain)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate TLS certificates: %w", err)
+	}
+
 	r := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
 			Name:  fmt.Sprintf("mock-%s-%s", p.Prefix, Tag),
@@ -34,7 +183,27 @@ func New(p RequestParams) (*testcontainers.GenericContainerRequest, error) {
 			ExposedPorts: []string{
 				Port,
 			},
-			WaitingFor: wait.ForLog(".*[info]: ready to rock!.*\\s").AsRegexp().WithOccurrence(1),
+			Env: map[string]string{
+				"KANIDM_DOMAIN":      DefaultDomain,
+				"KANIDM_ORIGIN":      DefaultOrigin,
+				"KANIDM_TLS_CHAIN":   "/data/chain.pem",
+				"KANIDM_TLS_KEY":     "/data/key.pem",
+				"KANIDM_BINDADDRESS": "0.0.0.0:8443",
+				"KANIDM_DB_PATH":     "/data/kanidm.db",
+			},
+			Files: []testcontainers.ContainerFile{
+				{
+					ContainerFilePath: "/data/chain.pem",
+					Reader:            bytes.NewReader(certPEM),
+					FileMode:          0o644,
+				},
+				{
+					ContainerFilePath: "/data/key.pem",
+					Reader:            bytes.NewReader(keyPEM),
+					FileMode:          0o600,
+				},
+			},
+			WaitingFor: wait.ForLog("ready to rock").WithStartupTimeout(120 * time.Second),
 		},
 		Started: true,
 	}
@@ -57,19 +226,26 @@ type ContainerParams struct {
 type Result struct {
 	fx.Out
 	Container      testcontainers.Container `name:"kanidm"`
-	ContainerGroup testcontainers.Container `name:"containers"`
+	ContainerGroup testcontainers.Container `group:"containers"`
 }
 
 func Actualize(p ContainerParams) (Result, error) {
 	c, err := testcontainers.GenericContainer(context.Background(), *p.Request)
 	if err != nil {
-		return Result{}, err
+		return Result{}, fmt.Errorf("an error occurred while instantiating %s container: %w", ContainerPrettyName, err)
 	}
 
 	p.Lifecycle.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
 			portLabels := map[string]string{
 				Port: "https",
+			}
+			// Check if LDAP port is exposed
+			for _, port := range p.Request.ExposedPorts {
+				if port == LDAPPort {
+					portLabels[LDAPPort] = "ldaps"
+					break
+				}
 			}
 			var ports []any
 			for port, label := range portLabels {
@@ -99,3 +275,16 @@ func Actualize(p ContainerParams) (Result, error) {
 		ContainerGroup: c,
 	}, nil
 }
+
+var WithPostReadyHook = mockestra.WithPostReadyHook
+
+var Module = mockestra.BuildContainerModule(
+	Tag,
+	fx.Provide(
+		fx.Annotate(
+			New,
+			fx.ResultTags(`name:"kanidm"`),
+		),
+		Actualize,
+	),
+)

--- a/kanidm/kanidm_test.go
+++ b/kanidm/kanidm_test.go
@@ -1,0 +1,430 @@
+package kanidm_test
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	container "github.com/narwhl/mockestra/kanidm"
+	"github.com/testcontainers/testcontainers-go"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestKanidmModule_SmokeTest(t *testing.T) {
+	app := fxtest.New(
+		t,
+		fx.NopLogger,
+		fx.Supply(
+			fx.Annotate(
+				"latest",
+				fx.ResultTags(`name:"kanidm_version"`),
+			),
+		),
+		fx.Supply(fx.Annotate(
+			fmt.Sprintf("kanidm-test-%x", time.Now().Unix()),
+			fx.ResultTags(`name:"prefix"`),
+		)),
+		container.Module(),
+		fx.Invoke(func(params struct {
+			fx.In
+			Container testcontainers.Container `name:"kanidm"`
+		}) {
+			endpoint, err := params.Container.PortEndpoint(context.Background(), container.Port, "https")
+			if err != nil {
+				t.Fatalf("Failed to get Kanidm endpoint: %v", err)
+			}
+
+			// Kanidm uses HTTPS with self-signed certs, so we need to skip TLS verification
+			tr := &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			}
+			client := &http.Client{Transport: tr}
+
+			// Test status endpoint
+			resp, err := client.Get(fmt.Sprintf("%s/status", endpoint))
+			if err != nil {
+				t.Fatalf("Failed to reach Kanidm status endpoint: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("Kanidm status check failed with status: %d", resp.StatusCode)
+			}
+
+			t.Logf("Kanidm container is running successfully at %s", endpoint)
+		}),
+	)
+
+	app.RequireStart()
+	t.Cleanup(app.RequireStop)
+}
+
+func TestKanidmModule_WithDomain(t *testing.T) {
+	customDomain := "auth.mycompany.com"
+
+	// Test the option directly without starting the container
+	req := &testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Env: make(map[string]string),
+		},
+	}
+
+	opt := container.WithDomain(customDomain)
+	if err := opt.Customize(req); err != nil {
+		t.Fatalf("Failed to customize request: %v", err)
+	}
+
+	if req.Env["KANIDM_DOMAIN"] != customDomain {
+		t.Fatalf("Expected KANIDM_DOMAIN to be %s, got %s", customDomain, req.Env["KANIDM_DOMAIN"])
+	}
+	t.Logf("WithDomain decorator correctly set domain to %s", customDomain)
+}
+
+func TestKanidmModule_WithOrigin(t *testing.T) {
+	customOrigin := "https://auth.mycompany.com:8443"
+
+	// Test the option directly without starting the container
+	req := &testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Env: make(map[string]string),
+		},
+	}
+
+	opt := container.WithOrigin(customOrigin)
+	if err := opt.Customize(req); err != nil {
+		t.Fatalf("Failed to customize request: %v", err)
+	}
+
+	if req.Env["KANIDM_ORIGIN"] != customOrigin {
+		t.Fatalf("Expected KANIDM_ORIGIN to be %s, got %s", customOrigin, req.Env["KANIDM_ORIGIN"])
+	}
+	t.Logf("WithOrigin decorator correctly set origin to %s", customOrigin)
+}
+
+func TestKanidmModule_WithBindAddress(t *testing.T) {
+	bindAddr := "0.0.0.0:443"
+
+	// Test the option directly without starting the container
+	req := &testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Env: make(map[string]string),
+		},
+	}
+
+	opt := container.WithBindAddress(bindAddr)
+	if err := opt.Customize(req); err != nil {
+		t.Fatalf("Failed to customize request: %v", err)
+	}
+
+	if req.Env["KANIDM_BINDADDRESS"] != bindAddr {
+		t.Fatalf("Expected KANIDM_BINDADDRESS to be %s, got %s", bindAddr, req.Env["KANIDM_BINDADDRESS"])
+	}
+	t.Logf("WithBindAddress decorator correctly set bind address to %s", bindAddr)
+}
+
+func TestKanidmModule_WithLDAPBindAddress(t *testing.T) {
+	ldapBindAddr := "0.0.0.0:3636"
+
+	// Test the option directly without starting the container
+	req := &testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Env:          make(map[string]string),
+			ExposedPorts: []string{container.Port},
+		},
+	}
+
+	opt := container.WithLDAPBindAddress(ldapBindAddr)
+	if err := opt.Customize(req); err != nil {
+		t.Fatalf("Failed to customize request: %v", err)
+	}
+
+	if req.Env["KANIDM_LDAPBINDADDRESS"] != ldapBindAddr {
+		t.Fatalf("Expected KANIDM_LDAPBINDADDRESS to be %s, got %s", ldapBindAddr, req.Env["KANIDM_LDAPBINDADDRESS"])
+	}
+
+	// Verify LDAP port is exposed
+	ldapPortExposed := false
+	for _, port := range req.ExposedPorts {
+		if port == container.LDAPPort {
+			ldapPortExposed = true
+			break
+		}
+	}
+	if !ldapPortExposed {
+		t.Fatal("LDAP port should be exposed when WithLDAPBindAddress is set")
+	}
+	t.Logf("WithLDAPBindAddress decorator correctly set LDAP bind address and exposed LDAP port")
+}
+
+func TestKanidmModule_WithLogLevel(t *testing.T) {
+	logLevel := "debug"
+
+	// Test the option directly without starting the container
+	req := &testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Env: make(map[string]string),
+		},
+	}
+
+	opt := container.WithLogLevel(logLevel)
+	if err := opt.Customize(req); err != nil {
+		t.Fatalf("Failed to customize request: %v", err)
+	}
+
+	if req.Env["KANIDM_LOG_LEVEL"] != logLevel {
+		t.Fatalf("Expected KANIDM_LOG_LEVEL to be %s, got %s", logLevel, req.Env["KANIDM_LOG_LEVEL"])
+	}
+	t.Logf("WithLogLevel decorator correctly set log level to %s", logLevel)
+}
+
+func TestKanidmModule_WithDBPath(t *testing.T) {
+	dbPath := "/custom/path/kanidm.db"
+
+	// Test the option directly without starting the container
+	req := &testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Env: make(map[string]string),
+		},
+	}
+
+	opt := container.WithDBPath(dbPath)
+	if err := opt.Customize(req); err != nil {
+		t.Fatalf("Failed to customize request: %v", err)
+	}
+
+	if req.Env["KANIDM_DB_PATH"] != dbPath {
+		t.Fatalf("Expected KANIDM_DB_PATH to be %s, got %s", dbPath, req.Env["KANIDM_DB_PATH"])
+	}
+	t.Logf("WithDBPath decorator correctly set database path to %s", dbPath)
+}
+
+func TestKanidmModule_WithDBFSType(t *testing.T) {
+	fsType := "zfs"
+
+	// Test the option directly without starting the container
+	req := &testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Env: make(map[string]string),
+		},
+	}
+
+	opt := container.WithDBFSType(fsType)
+	if err := opt.Customize(req); err != nil {
+		t.Fatalf("Failed to customize request: %v", err)
+	}
+
+	if req.Env["KANIDM_DB_FS_TYPE"] != fsType {
+		t.Fatalf("Expected KANIDM_DB_FS_TYPE to be %s, got %s", fsType, req.Env["KANIDM_DB_FS_TYPE"])
+	}
+	t.Logf("WithDBFSType decorator correctly set filesystem type to %s", fsType)
+}
+
+func TestKanidmModule_WithDBArcSize(t *testing.T) {
+	arcSize := 4096
+
+	// Test the option directly without starting the container
+	req := &testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Env: make(map[string]string),
+		},
+	}
+
+	opt := container.WithDBArcSize(arcSize)
+	if err := opt.Customize(req); err != nil {
+		t.Fatalf("Failed to customize request: %v", err)
+	}
+
+	expected := fmt.Sprintf("%d", arcSize)
+	if req.Env["KANIDM_DB_ARC_SIZE"] != expected {
+		t.Fatalf("Expected KANIDM_DB_ARC_SIZE to be %s, got %s", expected, req.Env["KANIDM_DB_ARC_SIZE"])
+	}
+	t.Logf("WithDBArcSize decorator correctly set arc size to %d", arcSize)
+}
+
+func TestKanidmModule_WithPostReadyHook(t *testing.T) {
+	hookCalled := false
+
+	app := fxtest.New(
+		t,
+		fx.NopLogger,
+		fx.Supply(
+			fx.Annotate(
+				"latest",
+				fx.ResultTags(`name:"kanidm_version"`),
+			),
+		),
+		fx.Supply(fx.Annotate(
+			fmt.Sprintf("kanidm-hook-test-%x", time.Now().Unix()),
+			fx.ResultTags(`name:"prefix"`),
+		)),
+		container.Module(
+			container.WithPostReadyHook(func(endpoints map[string]string) error {
+				hookCalled = true
+				t.Logf("Post-ready hook called for Kanidm container with endpoints: %v", endpoints)
+				return nil
+			}),
+		),
+		fx.Invoke(func(params struct {
+			fx.In
+			Container testcontainers.Container `name:"kanidm"`
+		}) {
+			// Give some time for the hook to be called
+			time.Sleep(100 * time.Millisecond)
+
+			if !hookCalled {
+				t.Fatal("Post-ready hook was not called")
+			}
+			t.Logf("WithPostReadyHook decorator successfully executed")
+		}),
+	)
+
+	app.RequireStart()
+	t.Cleanup(app.RequireStop)
+}
+
+func TestKanidmModule_MultipleDecorators(t *testing.T) {
+	domain := "auth.example.com"
+	origin := "https://auth.example.com:8443"
+	logLevel := "trace"
+
+	// Test multiple options directly without starting the container
+	req := &testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Env: make(map[string]string),
+		},
+	}
+
+	opts := []testcontainers.CustomizeRequestOption{
+		container.WithDomain(domain),
+		container.WithOrigin(origin),
+		container.WithLogLevel(logLevel),
+	}
+
+	for _, opt := range opts {
+		if err := opt.Customize(req); err != nil {
+			t.Fatalf("Failed to customize request: %v", err)
+		}
+	}
+
+	expectedEnvs := map[string]string{
+		"KANIDM_DOMAIN":    domain,
+		"KANIDM_ORIGIN":    origin,
+		"KANIDM_LOG_LEVEL": logLevel,
+	}
+
+	for key, expected := range expectedEnvs {
+		if req.Env[key] != expected {
+			t.Fatalf("Expected %s to be %s, got %s", key, expected, req.Env[key])
+		}
+	}
+	t.Logf("All decorators correctly applied their configurations")
+}
+
+func TestKanidmModule_FullIntegration(t *testing.T) {
+	app := fxtest.New(
+		t,
+		fx.NopLogger,
+		fx.Supply(
+			fx.Annotate(
+				"latest",
+				fx.ResultTags(`name:"kanidm_version"`),
+			),
+		),
+		fx.Supply(fx.Annotate(
+			fmt.Sprintf("kanidm-integration-test-%x", time.Now().Unix()),
+			fx.ResultTags(`name:"prefix"`),
+		)),
+		container.Module(
+			container.WithDomain("idm.test.local"),
+			container.WithOrigin("https://idm.test.local:8443"),
+			container.WithLogLevel("info"),
+		),
+		fx.Invoke(func(params struct {
+			fx.In
+			Container testcontainers.Container `name:"kanidm"`
+		}) {
+			// Verify container is running
+			state, err := params.Container.State(context.Background())
+			if err != nil {
+				t.Fatalf("Failed to get container state: %v", err)
+			}
+			if !state.Running {
+				t.Fatal("Kanidm container is not running")
+			}
+
+			// Verify endpoint is accessible
+			endpoint, err := params.Container.PortEndpoint(context.Background(), container.Port, "https")
+			if err != nil {
+				t.Fatalf("Failed to get endpoint: %v", err)
+			}
+
+			// Test status endpoint with HTTPS
+			tr := &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			}
+			client := &http.Client{Transport: tr}
+
+			resp, err := client.Get(fmt.Sprintf("%s/status", endpoint))
+			if err != nil {
+				t.Fatalf("Failed to reach Kanidm status endpoint: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("Kanidm status check returned status %d", resp.StatusCode)
+			}
+
+			t.Logf("Kanidm full integration test passed")
+			t.Logf("Endpoint: %s", endpoint)
+		}),
+	)
+
+	app.RequireStart()
+	t.Cleanup(app.RequireStop)
+}
+
+func TestKanidmModule_ContainerDefaults(t *testing.T) {
+	// Test defaults by directly calling New() function
+	// This avoids any state leakage from fxtest
+	params := container.RequestParams{
+		Prefix:  "test-defaults",
+		Version: "latest",
+		Opts:    nil,
+	}
+
+	req, err := container.New(params)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	// Verify default values are set
+	if req.Env["KANIDM_DOMAIN"] != container.DefaultDomain {
+		t.Fatalf("Expected default KANIDM_DOMAIN to be %s, got %s", container.DefaultDomain, req.Env["KANIDM_DOMAIN"])
+	}
+	if req.Env["KANIDM_ORIGIN"] != container.DefaultOrigin {
+		t.Fatalf("Expected default KANIDM_ORIGIN to be %s, got %s", container.DefaultOrigin, req.Env["KANIDM_ORIGIN"])
+	}
+	if req.Env["KANIDM_TLS_CHAIN"] == "" {
+		t.Fatal("Expected KANIDM_TLS_CHAIN to be set")
+	}
+	if req.Env["KANIDM_TLS_KEY"] == "" {
+		t.Fatal("Expected KANIDM_TLS_KEY to be set")
+	}
+	if req.Env["KANIDM_BINDADDRESS"] == "" {
+		t.Fatal("Expected KANIDM_BINDADDRESS to be set")
+	}
+	if req.Env["KANIDM_DB_PATH"] == "" {
+		t.Fatal("Expected KANIDM_DB_PATH to be set")
+	}
+
+	// Verify TLS files are added
+	if len(req.Files) < 2 {
+		t.Fatalf("Expected at least 2 files (cert and key), got %d", len(req.Files))
+	}
+
+	t.Logf("Container defaults are correctly configured")
+}

--- a/kanidm/radius.go
+++ b/kanidm/radius.go
@@ -1,1 +1,48 @@
 package kanidm
+
+// RadiusConfig represents the configuration for a Kanidm RADIUS server.
+// Note: Kanidm RADIUS runs as a separate container (kanidm/radius).
+// This configuration can be used to generate a radius.toml configuration file.
+type RadiusConfig struct {
+	// URI is the URL to the Kanidm server
+	URI string `toml:"uri"`
+	// AuthToken is the API token for the RADIUS service account
+	AuthToken string `toml:"auth_token"`
+	// VerifyHostnames enables hostname verification for the Kanidm server
+	VerifyHostnames bool `toml:"verify_hostnames"`
+	// VerifyCA enables strict CA verification
+	VerifyCA bool `toml:"verify_ca"`
+	// RadiusDefaultVLAN is the default VLAN for groups that don't specify one
+	RadiusDefaultVLAN int `toml:"radius_default_vlan"`
+	// RadiusRequiredGroups is a list of Kanidm groups which must be a member
+	// before they can authenticate via RADIUS
+	RadiusRequiredGroups []string `toml:"radius_required_groups"`
+	// RadiusGroups is a mapping between Kanidm groups and VLANs
+	RadiusGroups []RadiusGroup `toml:"radius_groups"`
+	// RadiusClients is a mapping of clients and their authentication tokens
+	RadiusClients []RadiusClient `toml:"radius_clients"`
+	// RadiusCertPath is the path to the RADIUS TLS certificate
+	RadiusCertPath string `toml:"radius_cert_path,omitempty"`
+	// RadiusKeyPath is the path to the RADIUS TLS key
+	RadiusKeyPath string `toml:"radius_key_path,omitempty"`
+	// RadiusCAPath is the path to the Kanidm CA certificate
+	RadiusCAPath string `toml:"radius_ca_path,omitempty"`
+}
+
+// RadiusGroup represents a mapping between a Kanidm group and a VLAN
+type RadiusGroup struct {
+	// SPN is the Security Principal Name of the group (e.g., "radius_access_allowed@idm.example.com")
+	SPN string `toml:"spn"`
+	// VLAN is the VLAN ID to assign to members of this group
+	VLAN int `toml:"vlan"`
+}
+
+// RadiusClient represents a RADIUS client configuration
+type RadiusClient struct {
+	// Name is the name of the client
+	Name string `toml:"name"`
+	// IPAddr is the IP address or CIDR range of the client
+	IPAddr string `toml:"ipaddr"`
+	// Secret is the shared secret for the client
+	Secret string `toml:"secret"`
+}

--- a/kanidm/radius.go
+++ b/kanidm/radius.go
@@ -1,0 +1,1 @@
+package kanidm


### PR DESCRIPTION
This pull request introduces a new module for Kanidm container orchestration and adds support for Kanidm RADIUS server configuration. The main changes include a complete implementation for managing Kanidm containers with testcontainers, helper functions for customizing container setup, and data structures for RADIUS configuration.

**Kanidm container orchestration:**

* Added a new `kanidm/kanidm.go` file that provides a comprehensive module for creating and managing Kanidm server containers using testcontainers, including lifecycle hooks and TLS certificate generation for secure startup.
* Implemented customizable options for container setup, such as domain, origin, bind addresses, log level, database path, and database tuning parameters, allowing flexible configuration for testing and development.

**RADIUS server configuration:**

* Introduced `kanidm/radius.go` with data structures (`RadiusConfig`, `RadiusGroup`, and `RadiusClient`) for representing Kanidm RADIUS server configuration, supporting features like group-to-VLAN mapping, client authentication, and TLS certificate paths.