### PR TITLE
test(registry): add test for WithBasicAuth option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	go.temporal.io/api v1.58.0
 	go.temporal.io/sdk v1.38.0
 	go.uber.org/fx v1.24.0
+	golang.org/x/crypto v0.45.0
 	golang.org/x/oauth2 v0.33.0
 	google.golang.org/protobuf v1.36.10
 	sigs.k8s.io/yaml v1.6.0
@@ -141,7 +142,6 @@ require (
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -66,6 +66,9 @@ func WithBasicAuth(htpasswdPath string) testcontainers.CustomizeRequestOption {
 			ContainerFilePath: "/auth/htpasswd",
 			FileMode:          0o644,
 		})
+		req.WaitingFor = wait.ForHTTP("/v2/").WithPort(Port).WithStatusCodeMatcher(func(status int) bool {
+			return status == 200 || status == 401
+		})
 		return nil
 	}
 }

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -3,6 +3,8 @@ package registry_test
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxtest"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func TestRegistryModule(t *testing.T) {
@@ -42,6 +45,76 @@ func TestRegistryModule(t *testing.T) {
 			defer resp.Body.Close()
 			if resp.StatusCode != http.StatusOK {
 				t.Errorf("unexpected status code: %d", resp.StatusCode)
+			}
+		}),
+	)
+
+	app.RequireStart()
+	t.Cleanup(app.RequireStop)
+}
+
+func TestRegistryWithBasicAuth(t *testing.T) {
+	username := "testuser"
+	password := "testpass"
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		t.Fatalf("failed to generate bcrypt hash: %v", err)
+	}
+
+	htpasswdPath := filepath.Join(t.TempDir(), "htpasswd")
+	if err := os.WriteFile(htpasswdPath, []byte(fmt.Sprintf("%s:%s\n", username, hash)), 0o644); err != nil {
+		t.Fatalf("failed to write htpasswd file: %v", err)
+	}
+
+	app := fxtest.New(
+		t,
+		fx.NopLogger,
+		fx.Supply(
+			fx.Annotate(
+				"2",
+				fx.ResultTags(`name:"registry_version"`),
+			),
+		),
+		fx.Supply(fx.Annotate(
+			fmt.Sprintf("registry-auth-test-%x", time.Now().Unix()),
+			fx.ResultTags(`name:"prefix"`),
+		)),
+		container.Module(
+			container.WithBasicAuth(htpasswdPath),
+		),
+		fx.Invoke(func(params struct {
+			fx.In
+			Container testcontainers.Container `name:"registry"`
+		}) {
+			endpoint, err := params.Container.PortEndpoint(t.Context(), container.Port, "http")
+			if err != nil {
+				t.Errorf("failed to get endpoint: %v", err)
+			}
+
+			// Unauthenticated request should return 401
+			resp, err := http.Get(fmt.Sprintf("%s/v2/", endpoint))
+			if err != nil {
+				t.Errorf("failed to reach registry: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusUnauthorized {
+				t.Errorf("expected 401 for unauthenticated request, got: %d", resp.StatusCode)
+			}
+
+			// Authenticated request should return 200
+			req, err := http.NewRequest("GET", fmt.Sprintf("%s/v2/", endpoint), nil)
+			if err != nil {
+				t.Errorf("failed to create request: %v", err)
+			}
+			req.SetBasicAuth(username, password)
+			authResp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Errorf("failed to reach registry with auth: %v", err)
+			}
+			defer authResp.Body.Close()
+			if authResp.StatusCode != http.StatusOK {
+				t.Errorf("expected 200 for authenticated request, got: %d", authResp.StatusCode)
 			}
 		}),
 	)


### PR DESCRIPTION
Fix WithBasicAuth wait strategy to accept 401 status code, as the registry returns 401 for unauthenticated requests when basic auth is enabled. Add integration test verifying both unauthenticated (401) and authenticated (200) responses.