### PR TITLE
feat(lgtm): add WithDashboard option for Grafana dashboard provisioning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,17 @@ name: Test
 
 on:
   push:
+    branches:
+      - main
     paths:
       - "**/*.go"
   pull_request:
     paths:
       - "**/*.go"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/lgtm/lgtm_test.go
+++ b/lgtm/lgtm_test.go
@@ -1,7 +1,10 @@
 package lgtm_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"testing"
 	"time"
 
@@ -62,6 +65,95 @@ func TestLGTMModule(t *testing.T) {
 				otelslog.WithLoggerProvider(provider),
 			)
 			logger.Info("LGTM container is ready")
+		}),
+	)
+	app.RequireStart()
+	t.Cleanup(app.RequireStop)
+}
+
+func TestWithDashboard(t *testing.T) {
+	app := fxtest.New(
+		t,
+		fx.StartTimeout(90*time.Second),
+		fx.NopLogger,
+		fx.Supply(
+			fx.Annotate(
+				"latest",
+				fx.ResultTags(`name:"lgtm_version"`),
+			),
+		),
+		fx.Supply(fx.Annotate(
+			fmt.Sprintf("lgtm-dashboard-test-%x", time.Now().Unix()),
+			fx.ResultTags(`name:"prefix"`),
+		)),
+		container.Module(
+			container.WithDashboard(
+				container.Dashboard{
+					Name: "test-dashboard",
+					JSON: `{
+						"uid": "test-dashboard",
+						"title": "Test Dashboard",
+						"panels": [],
+						"schemaVersion": 30
+					}`,
+				},
+				container.Dashboard{
+					Name: "test-dashboard-2",
+					JSON: `{
+						"uid": "test-dashboard-2",
+						"title": "Test Dashboard 2",
+						"panels": [],
+						"schemaVersion": 30
+					}`,
+				},
+			),
+		),
+		fx.Invoke(func(params struct {
+			fx.In
+			Container testcontainers.Container `name:"lgtm"`
+		}) {
+			endpoint, err := params.Container.PortEndpoint(t.Context(), container.GrafanaPort, "")
+			if err != nil {
+				t.Fatalf("Failed to get Grafana endpoint: %v", err)
+			}
+
+			grafanaURL := fmt.Sprintf("http://%s/api/search", endpoint)
+
+			var resp *http.Response
+			for range 10 {
+				resp, err = http.Get(grafanaURL)
+				if err == nil && resp.StatusCode == http.StatusOK {
+					break
+				}
+				time.Sleep(2 * time.Second)
+			}
+			if err != nil {
+				t.Fatalf("Failed to query Grafana API: %v", err)
+			}
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("Failed to read Grafana API response: %v", err)
+			}
+
+			var dashboards []map[string]any
+			if err := json.Unmarshal(body, &dashboards); err != nil {
+				t.Fatalf("Failed to parse Grafana API response: %v", err)
+			}
+
+			titles := make(map[string]bool)
+			for _, d := range dashboards {
+				if title, ok := d["title"].(string); ok {
+					titles[title] = true
+				}
+			}
+
+			for _, expected := range []string{"Test Dashboard", "Test Dashboard 2"} {
+				if !titles[expected] {
+					t.Fatalf("Dashboard %q not found in Grafana, got: %s", expected, string(body))
+				}
+			}
 		}),
 	)
 	app.RequireStart()


### PR DESCRIPTION
Add support for provisioning Grafana dashboards into the LGTM container via a variadic WithDashboard option that accepts Dashboard structs with name and JSON content. Dashboards are mounted into a shared directory with a single provisioning config.