### PR TITLE
Change Minio image repository to pgsty

### DIFF
--- a/minio/minio.go
+++ b/minio/minio.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	Tag         = "minio"
-	Image       = "ghcr.io/golithus/minio"
+	Image       = "pgsty/minio"
 	Port        = "9000/tcp"
 	ConsolePort = "9001/tcp"
 


### PR DESCRIPTION
This pull request makes a minor update to the MinIO image source in the `minio/minio.go` file, changing the image repository to `pgsty/minio` from the previous `ghcr.io/golithus/minio`.