### PR TITLE
feat(concourse): add WithExternalURL option for configurable external URL

### DIFF
--- a/concourse/concourse.go
+++ b/concourse/concourse.go
@@ -61,6 +61,12 @@ func WithSecret(secret string) testcontainers.CustomizeRequestOption {
 	})
 }
 
+func WithExternalURL(url string) testcontainers.CustomizeRequestOption {
+	return testcontainers.WithEnv(map[string]string{
+		"CONCOURSE_EXTERNAL_URL": url,
+	})
+}
+
 func New(p RequestParams) (*testcontainers.GenericContainerRequest, error) {
 	_, portNumber := nat.SplitProtoPort(Port)
 	r := testcontainers.GenericContainerRequest{


### PR DESCRIPTION
## Summary
- Add `WithExternalURL` option to the concourse module, allowing users to configure the `CONCOURSE_EXTERNAL_URL` environment variable
- The default external URL (`http://127.0.0.1:8080`) remains unchanged when the option is not used
- Follows the same `testcontainers.WithEnv` pattern as existing options (`WithMainTeamUser`, `WithSecret`)

## Test plan
- [ ] Verify `go build ./...` passes
- [ ] Verify existing concourse tests still pass (`go test ./concourse`)
- [ ] Verify `WithExternalURL` overrides the default `CONCOURSE_EXTERNAL_URL` when supplied
