### PR TITLE
feat(proxy): add WithListenPort option to decouple listen port from container port

### DIFF
--- a/concourse/proxy.go
+++ b/concourse/proxy.go
@@ -19,14 +19,19 @@ type ProxyParams struct {
 	Lifecycle          fx.Lifecycle
 }
 
-func NewProxy(portName string, port nat.Port) func(p ProxyParams) (*proxy.TCPProxy, error) {
+// NewProxy creates a TCPProxy that forwards local traffic to the Concourse container.
+// portName is a human-readable label for logging (e.g., "API").
+// port is the container's exposed port used for the Docker port lookup (e.g., nat.Port(Port)).
+// Use [proxy.WithListenPort] to override which local port the proxy binds to;
+// by default it listens on the same port number as the container port.
+func NewProxy(portName string, port nat.Port, opts ...proxy.Option) func(p ProxyParams) (*proxy.TCPProxy, error) {
 	return func(p ProxyParams) (*proxy.TCPProxy, error) {
 		concourseEndpoint, err := p.ConcourseContainer.PortEndpoint(context.Background(), port, "")
 		if err != nil {
 			return nil, fmt.Errorf("failed to get concourse %s endpoint: %w", portName, err)
 		}
 		accessProxy := proxy.TCPProxy{
-			ListenAddress: net.JoinHostPort(mockestra.LoopbackAddress, port.Port()),
+			ListenAddress: net.JoinHostPort(mockestra.LoopbackAddress, proxy.ResolveListenPort(port, opts...)),
 			TargetAddress: concourseEndpoint,
 		}
 		if err := accessProxy.Start(context.Background()); err != nil {

--- a/hydra/proxy.go
+++ b/hydra/proxy.go
@@ -19,14 +19,19 @@ type ProxyParams struct {
 	Lifecycle      fx.Lifecycle
 }
 
-func NewProxy(portName string, port nat.Port) func(p ProxyParams) (*proxy.TCPProxy, error) {
+// NewProxy creates a TCPProxy that forwards local traffic to the Hydra container.
+// portName is a human-readable label for logging (e.g., "Public API", "Admin API").
+// port is the container's exposed port used for the Docker port lookup (e.g., nat.Port(Port)).
+// Use [proxy.WithListenPort] to override which local port the proxy binds to;
+// by default it listens on the same port number as the container port.
+func NewProxy(portName string, port nat.Port, opts ...proxy.Option) func(p ProxyParams) (*proxy.TCPProxy, error) {
 	return func(p ProxyParams) (*proxy.TCPProxy, error) {
 		hydraAPIEndpoint, err := p.HydraContainer.PortEndpoint(context.Background(), port, "")
 		if err != nil {
 			return nil, fmt.Errorf("failed to get hydra %s endpoint: %w", portName, err)
 		}
 		apiAccessProxy := proxy.TCPProxy{
-			ListenAddress: net.JoinHostPort(mockestra.LoopbackAddress, port.Port()),
+			ListenAddress: net.JoinHostPort(mockestra.LoopbackAddress, proxy.ResolveListenPort(port, opts...)),
 			TargetAddress: hydraAPIEndpoint,
 		}
 		if err := apiAccessProxy.Start(context.Background()); err != nil {

--- a/kratos/proxy.go
+++ b/kratos/proxy.go
@@ -19,14 +19,19 @@ type ProxyParams struct {
 	Lifecycle       fx.Lifecycle
 }
 
-func NewProxy(portName string, port nat.Port) func(p ProxyParams) (*proxy.TCPProxy, error) {
+// NewProxy creates a TCPProxy that forwards local traffic to the Kratos container.
+// portName is a human-readable label for logging (e.g., "Public API", "Admin API").
+// port is the container's exposed port used for the Docker port lookup (e.g., nat.Port(Port)).
+// Use [proxy.WithListenPort] to override which local port the proxy binds to;
+// by default it listens on the same port number as the container port.
+func NewProxy(portName string, port nat.Port, opts ...proxy.Option) func(p ProxyParams) (*proxy.TCPProxy, error) {
 	return func(p ProxyParams) (*proxy.TCPProxy, error) {
 		kratosAPIEndpoint, err := p.KratosContainer.PortEndpoint(context.Background(), port, "")
 		if err != nil {
 			return nil, fmt.Errorf("failed to get %s %s endpoint: %w", ContainerPrettyName, portName, err)
 		}
 		apiAccessProxy := proxy.TCPProxy{
-			ListenAddress: net.JoinHostPort(mockestra.LoopbackAddress, port.Port()),
+			ListenAddress: net.JoinHostPort(mockestra.LoopbackAddress, proxy.ResolveListenPort(port, opts...)),
 			TargetAddress: kratosAPIEndpoint,
 		}
 		if err := apiAccessProxy.Start(context.Background()); err != nil {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -4,8 +4,46 @@ import (
 	"context"
 	"io"
 	"net"
+	"strconv"
 	"sync"
+
+	"github.com/docker/go-connections/nat"
 )
+
+// Option configures the behavior of a TCPProxy created by NewProxy.
+type Option func(*proxyConfig)
+
+type proxyConfig struct {
+	listenPort string
+}
+
+// WithListenPort overrides the local port the proxy listens on.
+// By default, the proxy listens on the same port number as the container's
+// exposed port. Use this option when the proxy must bind to a specific local
+// port that differs from the container port (e.g., a pre-allocated ephemeral port).
+//
+// Example:
+//
+//	concourse.NewProxy("API", nat.Port(concourse.Port), proxy.WithListenPort(58033))
+func WithListenPort(port int) Option {
+	return func(c *proxyConfig) {
+		c.listenPort = strconv.Itoa(port)
+	}
+}
+
+// ResolveListenPort determines the local port for the proxy to listen on.
+// It applies the given options and returns the overridden port if [WithListenPort]
+// was provided, otherwise falls back to the port number from containerPort.
+func ResolveListenPort(containerPort nat.Port, opts ...Option) string {
+	cfg := &proxyConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+	if cfg.listenPort != "" {
+		return cfg.listenPort
+	}
+	return containerPort.Port()
+}
 
 type TCPProxy struct {
 	ListenAddress string


### PR DESCRIPTION
## Summary

- Add `proxy.Option` functional option type and `proxy.WithListenPort(port int)` to allow callers to override the local listen port independently from the container's exposed port
- Update `NewProxy` in concourse, hydra, and kratos packages to accept `...proxy.Option` (backward-compatible, existing callers pass zero options)
- Add doc comments to `NewProxy`, `WithListenPort`, and `ResolveListenPort`

## Motivation

`NewProxy` uses the `port` parameter for two purposes: looking up the container's mapped port via `PortEndpoint` and determining the local proxy listen address. This couples the two together, so the proxy always listens on the same port number as the container exposes.

This breaks when a caller needs the proxy to listen on a different port — for example, when configuring `WithExternalURL` with a pre-allocated ephemeral port. Passing the ephemeral port to `NewProxy` causes the `PortEndpoint` lookup to fail because the container only exposes its own internal port (e.g., `8080/tcp`), not the caller's random port.

## Usage

```go
// Before: listen port is always the container port
concourse.NewProxy("API", nat.Port(concourse.Port))

// After: override listen port with a pre-allocated ephemeral port
concourse.NewProxy("API", nat.Port(concourse.Port), proxy.WithListenPort(58033))
```

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Existing module vars (concourse, hydra, kratos) call `NewProxy` with zero options — no behavioral change
- [ ] Verify proxy listens on overridden port when `WithListenPort` is provided
